### PR TITLE
Dockerize blog

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+./.git/
+./tmp/
+./log/
+./.gitignore
+./Dockerfile*
+./docker-compose*yml
+./.circle/
+./build
+./coverage-html
+./docs/_site

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .jekyll-metadata
 _site
+.sass-cache/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ruby:2.5.0
+
+WORKDIR /tmp
+ADD Gemfile /tmp/
+ADD Gemfile.lock /tmp/
+RUN gem install bundler && bundle install
+
+COPY . /jekyll
+WORKDIR /jekyll
+
+EXPOSE 4000
+CMD ["bundle", "exec", "jekyll", "serve", "--incremental"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,30 +1,14 @@
 source "https://rubygems.org"
+ruby '2.5.0'
 
-# Hello! This is where you manage which Jekyll version is used to run.
-# When you want to use a different version, change it below, save the
-# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
-#
-#     bundle exec jekyll serve
-#
-# This will help ensure the proper Jekyll version is running.
-# Happy Jekylling!
-gem "jekyll", "~> 3.7.0"
-
-# This is the default theme for new Jekyll sites. You may change this to anything you like.
-gem "minima", "~> 2.0"
-
-# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
-# uncomment the line below. To upgrade, run `bundle update github-pages`.
-# gem "github-pages", group: :jekyll_plugins
-
-# If you have any plugins, put them here!
+gem "jekyll"
+gem "minima"
 group :jekyll_plugins do
-  #gem "jekyll-feed", "~> 0.6"
-  gem "jekyll-gist", "~> 1.4.1"
-  gem "jekyll-redirect-from", "~> 0.12.1"
+  gem "jekyll-gist"
+  gem "jekyll-redirect-from"
+  gem "jekyll-feed"
 end
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-
-gem 'wdm', '>= 0.1.0'
+gem "json"
+gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby, :x64_mingw_25]
+gem 'wdm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,15 +8,17 @@ GEM
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
+    eventmachine (1.2.5)
     eventmachine (1.2.5-x64-mingw32)
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.18-x64-mingw32)
+    ffi (1.9.23)
+    ffi (1.9.23-x64-mingw32)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
-    i18n (0.9.1)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.7.0)
+    jekyll (3.7.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -29,16 +31,19 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
-    jekyll-feed (0.9.2)
+    jekyll-feed (0.9.3)
       jekyll (~> 3.3)
     jekyll-gist (1.4.1)
       octokit (~> 4.2)
-    jekyll-redirect-from (0.12.1)
+    jekyll-redirect-from (0.13.0)
       jekyll (~> 3.3)
-    jekyll-sass-converter (1.5.1)
+    jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
+    jekyll-seo-tag (2.4.0)
+      jekyll (~> 3.3)
     jekyll-watch (2.0.0)
       listen (~> 3.0)
+    json (2.1.0)
     kramdown (1.16.2)
     liquid (4.0.0)
     listen (3.1.5)
@@ -46,21 +51,23 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
     mercenary (0.3.6)
-    minima (2.1.1)
-      jekyll (~> 3.3)
+    minima (2.4.0)
+      jekyll (~> 3.5)
+      jekyll-feed (~> 0.9)
+      jekyll-seo-tag (~> 2.1)
     multipart-post (2.0.0)
     octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
-    public_suffix (3.0.1)
-    rb-fsevent (0.10.2)
+    public_suffix (3.0.2)
+    rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rouge (3.1.0)
+    rouge (3.1.1)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
-    sass (3.5.5)
+    sass (3.5.6)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -69,23 +76,28 @@ GEM
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2017.3)
+    tzinfo-data (1.2018.4)
       tzinfo (>= 1.0.0)
     wdm (0.1.1)
 
 PLATFORMS
+  ruby
   x64-mingw32
 
 DEPENDENCIES
-  jekyll (~> 3.7.0)
-  jekyll-feed (~> 0.6)
-  jekyll-gist (~> 1.4.1)
-  jekyll-redirect-from (~> 0.12.1)
-  minima (~> 2.0)
+  jekyll
+  jekyll-feed
+  jekyll-gist
+  jekyll-redirect-from
+  json
+  minima
   tzinfo-data
-  wdm (>= 0.1.0)
+  wdm
+
+RUBY VERSION
+   ruby 2.5.0p0
 
 BUNDLED WITH
    1.16.1

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY : help
+help: # Display help
+	@awk -F ':|##' \
+		'/^[^\t].+?:.*?##/ {\
+			printf "\033[36m%-30s\033[0m %s\n", $$1, $$NF \
+		}' $(MAKEFILE_LIST)
+
+.PHONY : all
+all : stop run ## all the things
+
+.PHONY : run
+run : ## run containers
+	@docker-compose up -d
+
+.PHONY : stop
+stop : ## stop containers
+	@docker-compose down

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # The Los Techies Blog
 
 See the [wiki](https://github.com/lostechies/blog/wiki) for guidance.
+
+# Docker
+
+To run locally:
+
+    make run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  jekyll:
+    container_name: jekyll_1
+    build: .
+    ports:
+      - 4000:4000
+    volumes:
+      - .:/jekyll


### PR DESCRIPTION
Prerequisite: docker installed
was tested on my local Ubuntu 17.10 laptop

To run locally:

    make run

takes a little while to generate the first time (~ 3mins)

```
[dockerize]->$ docker logs -f jekyll_1
Configuration file: /jekyll/_config.yml
            Source: /jekyll
       Destination: /jekyll/_site
 Incremental build: enabled
      Generating... 
                           done in 195.329 seconds.
```

subsequent updates take less than 20 seconds

then go to `http://localhost:4000` to view lostechies blog

If you see an error about unable to watch directory changes you need to run this on your host:

```
$ sudo sysctl fs.inotify.max_user_watches=524288
$ sudo sysctl -p
```

this increases the number of directories your OS can watch

## make run output

```
[dockerize]->$ make run
Creating network "blog_default" with the default driver
Building jekyll
Step 1/9 : FROM ruby:2.5.0
2.5.0: Pulling from library/ruby
c73ab1c6897b: Pull complete
1ab373b3deae: Pull complete
b542772b4177: Pull complete
57c8de432dbe: Pull complete
1785850988c5: Pull complete
953e617a9c21: Pull complete
aa1f26029ba5: Pull complete
0ee3623a364d: Pull complete
Digest: sha256:cde5649ea901f6b36714b69a0ad8717ddaffa42131343dba30a02b61f3177fca
Status: Downloaded newer image for ruby:2.5.0
 ---> 213a086149f6
Step 2/9 : WORKDIR /tmp
Removing intermediate container f1504d2c007b
 ---> 98058f0e7ea5
Step 3/9 : ADD Gemfile /tmp/
 ---> fbe710e084ff
Step 4/9 : ADD Gemfile.lock /tmp/
 ---> 017878953454
Step 5/9 : RUN gem install bundler && bundle install
 ---> Running in d7a91657d0b3
Successfully installed bundler-1.16.1
1 gem installed
Fetching gem metadata from https://rubygems.org/............
Fetching public_suffix 3.0.2
Installing public_suffix 3.0.2
Fetching addressable 2.5.2
Installing addressable 2.5.2
Using bundler 1.16.1
Fetching colorator 1.1.0
Installing colorator 1.1.0
Fetching concurrent-ruby 1.0.5
Installing concurrent-ruby 1.0.5
Fetching eventmachine 1.2.5
Installing eventmachine 1.2.5 with native extensions
Fetching http_parser.rb 0.6.0
Installing http_parser.rb 0.6.0 with native extensions
Fetching em-websocket 0.5.1
Installing em-websocket 0.5.1
Fetching multipart-post 2.0.0
Installing multipart-post 2.0.0
Fetching faraday 0.14.0
Installing faraday 0.14.0
Fetching ffi 1.9.23
Installing ffi 1.9.23 with native extensions
Fetching forwardable-extended 2.6.0
Installing forwardable-extended 2.6.0
Fetching i18n 0.9.5
Installing i18n 0.9.5
Fetching rb-fsevent 0.10.3
Installing rb-fsevent 0.10.3
Fetching rb-inotify 0.9.10
Installing rb-inotify 0.9.10
Fetching sass-listen 4.0.0
Installing sass-listen 4.0.0
Fetching sass 3.5.6
Installing sass 3.5.6
Fetching jekyll-sass-converter 1.5.2
Installing jekyll-sass-converter 1.5.2
Fetching ruby_dep 1.5.0
Installing ruby_dep 1.5.0
Fetching listen 3.1.5
Installing listen 3.1.5
Fetching jekyll-watch 2.0.0
Installing jekyll-watch 2.0.0
Fetching kramdown 1.16.2
Installing kramdown 1.16.2
Fetching liquid 4.0.0
Installing liquid 4.0.0
Fetching mercenary 0.3.6
Installing mercenary 0.3.6
Fetching pathutil 0.16.1
Installing pathutil 0.16.1
Fetching rouge 3.1.1
Installing rouge 3.1.1
Fetching safe_yaml 1.0.4
Installing safe_yaml 1.0.4
Fetching jekyll 3.7.3
Installing jekyll 3.7.3
Fetching jekyll-feed 0.9.3
Installing jekyll-feed 0.9.3
Fetching sawyer 0.8.1
Installing sawyer 0.8.1
Fetching octokit 4.8.0
Installing octokit 4.8.0
Fetching jekyll-gist 1.4.1
Installing jekyll-gist 1.4.1
Fetching jekyll-redirect-from 0.13.0
Installing jekyll-redirect-from 0.13.0
Fetching jekyll-seo-tag 2.4.0
Installing jekyll-seo-tag 2.4.0
Using json 2.1.0
Fetching minima 2.4.0
Installing minima 2.4.0
Fetching wdm 0.1.1
Installing wdm 0.1.1 with native extensions
Bundle complete! 8 Gemfile dependencies, 37 gems now installed.
Bundled gems are installed into `/usr/local/bundle`
Removing intermediate container d7a91657d0b3
 ---> 6c45f2e1ba8f
Step 6/9 : COPY . /jekyll
 ---> fa0ae60b76f6
Step 7/9 : WORKDIR /jekyll
Removing intermediate container 820702b9cbe2
 ---> 8b9061a6396c
Step 8/9 : EXPOSE 4000
 ---> Running in 4e24691daf7d
Removing intermediate container 4e24691daf7d
 ---> a7403e83515b
Step 9/9 : CMD ["bundle", "exec", "jekyll", "serve", "--incremental"]
 ---> Running in da497341eac6
Removing intermediate container da497341eac6
 ---> a0f9c12aa5ab
Successfully built a0f9c12aa5ab
Successfully tagged blog_jekyll:latest
WARNING: Image for service jekyll was built because it did not already exist. To rebuild this image you must use `docker-compose build` or `docker-compose up --build`.
Creating jekyll_1 ... done
```

