### PR TITLE
chore(codeowners): assign per-author ownership of blog directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,46 @@
+# Default owner for everything not matched below.
 * @jmeridth
+
+# Per-author ownership: each author owns their blog directory.
+# Only directories whose name matches a confirmed GitHub username are listed here;
+# anything not listed falls through to the default owner above.
+/_andrewsiemer/    @andrewsiemer
+/_bradcarleton/    @techpines
+/_chadmyers/       @chadmyers
+/_chrismissal/     @ChrisMissal
+/_chrispatterson/  @chrispatterson
+/_christaylor/     @christaylor
+/_colinjack/       @colinjack
+/_colinramsay/     @colinramsay
+/_derekgreer/      @derekgreer
+/_derickbailey/    @mxriverlynn
+/_derikwhittaker/  @derikwhittaker
+/_ericanderson/    @ericanderson
+/_erichexter/      @erichexter
+/_evanhoff/        @evanhoff
+/_gabrielschenker/ @gabrielschenker
+/_gregorylong/     @gregorylong
+/_hugobonacci/     @hugoware
+/_jamesgregory/    @JamesGregory
+/_jasdeepsingh/    @jasdeepsingh
+/_jimmybogard/     @jbogard
+/_joeocampo/       @joeocampo
+/_joeybeninghove/  @joeybeninghove
+/_johnteague/      @JohnTeague
+/_josharnold/      @josharnold
+/_joshuaflanagan/  @joshuaflanagan
+/_joshualockwood/  @JoshuaLockwood
+/_keithdahlby/     @dahlbyk
+/_matthinze/       @matthinze
+/_mokhan/          @mokhan
+/_patricklioi/     @plioi
+/_rayhouston/      @RayHouston
+/_rodpaddock/      @rodpaddock
+/_ryanrauh/        @rauhryan
+/_ryansvihla/      @foundev
+/_scottdensmore/   @scottdensmore
+/_scottreynolds/   @scottreynolds
+/_seanbiefeld/     @seanbiefeld
+/_seanchambers/    @seanchambers
+/_sharoncichelli/  @scichelli
+/_stevedonie/      @SteveDonie


### PR DESCRIPTION
## What

Map each `_<author>/` directory to its author's confirmed GitHub username so authors are auto-requested as the code owner for changes inside their own blog. The default `* @jmeridth` rule remains as the catch-all for any path not covered by a per-author entry.

## Why

The previous CODEOWNERS routed every PR to @jmeridth, which doesn't scale as authors return to update their own posts. Per-directory ownership lets each author be the required reviewer on their own content while keeping shared infrastructure (workflows, layouts, config, other authors' folders) under the default owner.

## Notes

- **Most listed users currently lack repo write access**, so GitHub's CODEOWNERS validator reports them as "Unknown owner" (visible at `https://github.com/lostechies/blog/settings/codeowners` once merged). Of 32 per-author entries, only 11 resolve as code owners today (already collaborators): `chadmyers`, `derekgreer`, `erichexter`, `jbogard`, `joshuaflanagan`, `dahlbyk`, `RayHouston`, `rauhryan`, `seanbiefeld`, `scichelli`, `SteveDonie`. The remaining 21 entries are syntactically valid and will activate automatically as those users are granted collaborator access — until then GitHub silently ignores them and the catch-all owner still applies.
- Two author directories were intentionally left unmapped because no confirmed GitHub username was provided: `_nelsonmontalvo`, `_scottgillenwater`. Those continue to fall through to the default owner.
- CODEOWNERS alone does not grant merge permissions. For an author to self-merge their own blog PR, branch-protection / ruleset settings on `main` need to either not require approvals or grant a code-owner bypass on that author's paths. GitHub still refuses to let a PR author approve their own PR even when they are the sole code owner of the path.
- The last matching rule wins, so per-author lines override `* @jmeridth` for those paths — @jmeridth is no longer a code owner inside an author's folder. If you want @jmeridth as a backup approver per directory, those lines need to be amended to list both handles.

## Testing

- Verified each per-author GitHub login exists via a single GraphQL `user(login:)` lookup before adding it to the file (30 directory-name-matches + 8 manually-provided handles confirmed).
- Ran GitHub's own CODEOWNERS validator against the pushed branch (`GET /repos/lostechies/blog/codeowners/errors?ref=chore/codeowners-per-author`); the only errors reported are the "Unknown owner" / no-write-access warnings called out in Notes. No syntax errors.