### PR TITLE
fix: exclude future-dated posts from feed and sidebar

### DIFF
--- a/_includes/author_archive.html
+++ b/_includes/author_archive.html
@@ -3,7 +3,7 @@
   {% assign author_posts = ''|split:''%}
   {% assign unfiltered_posts = site[page.collection] %}
   {% for post in unfiltered_posts %}
-  {% if post.index != true %}
+  {% if post.index != true and post.date <= site.time %}
   {% assign author_posts = author_posts|push:post%}
   {% endif %}
   {% endfor %}

--- a/_includes/author_posts.html
+++ b/_includes/author_posts.html
@@ -1,7 +1,7 @@
   {% assign author_posts = ''|split:''%}
   {% assign unfiltered_posts = site[page.collection] %}
   {% for post in unfiltered_posts %}
-  {% if post.index != true %}
+  {% if post.index != true and post.date <= site.time %}
   {% assign author_posts = author_posts|push:post%}
   {% endif %}
   {% endfor %}

--- a/_includes/author_tags.html
+++ b/_includes/author_tags.html
@@ -16,7 +16,7 @@
     {% assign counter = 1 %}
   	<ul>
   	{% for p in site[page.collection] %}
-  	{% if p.tags contains previousTag %}
+  	{% if p.tags contains previousTag and p.date <= site.time %}
         <li><a href="{{site.baseurl}}{{ p.url }}"><span class="archive-entry">{{ p.title }}</span></a></li>
   	{% endif %}
   	{% endfor %}
@@ -29,7 +29,7 @@
     <h2>{{ currentTag }} ({{ counter }})</h2>
   	<ul>
   	{% for p in site[page.collection] %}
-  	{% if p.tags contains currentTag %}
+  	{% if p.tags contains currentTag and p.date <= site.time %}
         <li><a href="{{site.baseurl}}{{ p.url }}"><span class="archive-entry"/>{{ p.title }}</span></a></li>
   	{% endif %}
   	{% endfor %}

--- a/feed.xml
+++ b/feed.xml
@@ -35,7 +35,7 @@ layout: nil
     </author>
   {% endif %}
 
-  {% assign posts = site.documents | where_exp: "post", "post.draft != true" | where_exp: "post", "post.index != true" | sort: 'date' | reverse %}
+  {% assign posts = site.documents | where_exp: "post", "post.draft != true" | where_exp: "post", "post.index != true" | where_exp: "post", "post.date <= site.time" | sort: 'date' | reverse %}
   {% for post in posts limit: 10 %}
     <entry{% if post.lang %}{{" "}}xml:lang="{{ post.lang }}"{% endif %}>
       <title type="html">{{ post.title | smartify | strip_html | normalize_whitespace | xml_escape }}</title>


### PR DESCRIPTION
## Summary

- `future: false` in `_config.yml` suppresses individual post pages for future-dated posts but does not filter Liquid collection loops
- All four templates were iterating `site.documents` / `site[page.collection]` with no date guard, causing scheduled posts to appear in the RSS feed and sidebar before their publish date
- Added `post.date <= site.time` check to each

## Files changed

| File | Fix |
|---|---|
| `feed.xml` | Added `where_exp: "post", "post.date <= site.time"` to the assign chain |
| `_includes/author_posts.html` | Added date check to the `if` gate in the build loop |
| `_includes/author_archive.html` | Same as author_posts |
| `_includes/author_tags.html` | Added date check to both inner loops (previousTag flush + forloop.last flush) |

## Test plan

- [ ] Confirm future-dated posts no longer appear in `/feed.xml` after merge
- [ ] Confirm future-dated posts no longer appear in author sidebar / archive / tags pages
- [ ] Confirm published posts still appear normally