### PR TITLE
fix: filter future-dated posts from client-side feed renderers

### DIFF
--- a/assets/js/load-aggregate-posts.js
+++ b/assets/js/load-aggregate-posts.js
@@ -16,7 +16,11 @@ function loadAggregatePosts(elementId, feed, loadFullText, collection) {
     getFeed(feed).then(function (result) {
       hostElement.innerHTML = "";
 
-      var posts = result.items;
+      var now = new Date();
+      var posts = result.items.filter(function (post) {
+        if (!post.pubDate) { return true; }
+        return new Date(post.pubDate.replace(/-/g, "/")) <= now;
+      });
       posts.map(function (post) {
         var box = createNode('div');
         var external = createNode('div');

--- a/assets/js/load-recent-author-posts.js
+++ b/assets/js/load-recent-author-posts.js
@@ -35,7 +35,11 @@ function loadRecentAuthorPosts(elementId, container) {
     getFeed(collectionFeed).then(function (result) {
       hostElement.innerHTML = "";
 
-      var posts = result.items.slice(0, 10);
+      var now = new Date();
+      var posts = result.items.filter(function (post) {
+        if (!post.pubDate) { return true; }
+        return new Date(post.pubDate.replace(/-/g, "/")) <= now;
+      }).slice(0, 10);
       posts.map(function (post) {
         var li = createNode('li'),
             anchor = createNode('a'),

--- a/assets/js/load-recent-posts.js
+++ b/assets/js/load-recent-posts.js
@@ -14,7 +14,11 @@ function loadRecentPosts(elementId) {
     getFeed(feed).then(function (result) {
       hostElement.innerHTML = "";
 
-      var posts = result.items.slice(0, 10);
+      var now = new Date();
+      var posts = result.items.filter(function (post) {
+        if (!post.pubDate) { return true; }
+        return new Date(post.pubDate.replace(/-/g, "/")) <= now;
+      }).slice(0, 10);
       posts.map(function (post) {
         var li = createNode('li'),
             anchor = createNode('a'),


### PR DESCRIPTION
## What

Filter out future-dated posts in the three JS files that render post lists from the third-party RSS aggregator:

- `assets/js/load-aggregate-posts.js` — home page cards
- `assets/js/load-recent-posts.js` — sidebar "Recent Posts"
- `assets/js/load-recent-author-posts.js` — per-author sidebar

In the two recent-posts files, the existing `.slice(0, 10)` now runs *after* the filter so legitimate posts aren't pushed out of the visible window by future ones.

## Why

PR #62 added future-post filtering to `feed.xml` and to Liquid-rendered sidebar widgets, but the home page card list and the JS-driven Recent Posts widgets are populated client-side from `feed.informer.com`, which serves whatever it has cached — including future-dated entries. Users saw a card or sidebar link for a post whose pubDate hadn't arrived yet, and clicking it 404'd because Jekyll's `future: false` excluded the actual post file from the build. This closes the gap so future-post hiding is consistent across all four post-list surfaces (server-side feed, server-side sidebar, client-side aggregate, client-side recent).

## Notes

- The \`.replace(/-/g, "/")\` in the date parse is the same Safari workaround already used at \`aggregate.js:77\`. Keeping it consistent.
- Posts with no \`pubDate\` are kept (defensive default — better to show than silently drop).
- For the recent-posts files, the visible list now fills to 10 non-future posts instead of "10 minus future count" — intended behavior.
- No third-party (feed.informer.com) change required; the filter is purely client-side.

## Testing

- Verify in a browser with a future-dated post in the feed (such as \`_erichexter/2026-06-06-local-llm-bench-part-5-final-picks.md\` while today is before 2026-06-06): the post should not appear in the home page cards, the sidebar "Recent Posts", or any author's "Recent Author Posts" sidebar.
- Verify that once the pubDate is reached, the post appears in all three surfaces without any further code change.
- Verify on prod that the 2026-06-06 post (visible on the home page today) disappears after deploy.