### PR TITLE
fix: remove invalid layout: nil from feed.xml

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -1,6 +1,5 @@
 ---
 permalink: /feed.xml
-layout: nil
 ---
 <?xml version="1.0" encoding="utf-8"?>
 {% if page.xsl %}


### PR DESCRIPTION
Closes #76

## What

Delete the \`layout: nil\` line from \`feed.xml\`'s front matter.

## Why

\`nil\` was being parsed as the YAML string \`"nil"\`, not as null. Jekyll then tried to resolve a layout file named \`nil\` and emitted \`Build Warning: Layout 'nil' requested in feed.xml does not exist.\` on every build. Removing the key entirely produces the intended behavior (no layout wraps the XML output) and removes the warning.

## Notes

- The generated \`/feed.xml\` output is byte-identical to before; this change only suppresses a build-time warning.
- An equivalent fix is \`layout: null\` (proper YAML null), but removing the key is unambiguous and free of conventions to remember.

## Testing

- Run \`bundle exec jekyll build\` (or \`jekyll serve\`) and confirm the \`Build Warning: Layout 'nil' requested in feed.xml does not exist.\` line no longer appears.
- \`diff _site/feed.xml\` before vs after this change confirms output is byte-identical (apart from any timestamps in \`<updated>\` tags).