### PR TITLE
chore: remove cdnjs polyfill and dead UA Google Analytics tag

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,7 +11,6 @@
 </footer>
 
 <!-- common js -->
-<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0" integrity="sha384-i0IGVuZBkKZqwXTD4CH4kcksIbFx7WKFMdxN8zUhLFHpLdELF0ym0jxa6UvLhW8/ sha384-3d4jRKquKl90C9aFG+eH4lPJmtbPHgACWHrp+VomFOxF8lzx2jxqeYkhpRg18UWC" crossorigin="anonymous"></script>
 <script src="{{ site.baseurl }}/assets/js/fetch.js"></script>
 <script src="{{ site.baseurl }}/assets/js/collections.js"></script>
 <script src="{{ site.baseurl }}/assets/js/dom.js"></script>
@@ -21,13 +20,3 @@
 <script src="{{ site.baseurl }}/assets/js/feed.js"></script>
 <script src="{{ site.baseurl }}/assets/js/load-authors.js"></script>
 <script src="{{ site.baseurl }}/assets/js/load-recent-posts.js"></script>
-
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-1265430-2"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'UA-1265430-2');
-</script>


### PR DESCRIPTION
Closes #70

## What

Delete two \`<script>\` blocks from \`_includes/footer.html\`:

- the \`cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0\` script (with its SRI hashes), and
- the Universal Analytics gtag block targeting \`UA-1265430-2\` (the \`googletagmanager.com\` script tag plus the inline \`dataLayer\` / \`gtag('config', ...)\` initialization).

## Why

The polyfill bundle covered IE 11 and pre-2017 browsers. Audit of the site's JS shows every feature used (\`fetch\`, \`Promise\`, \`Array.filter\` / \`map\`, \`localStorage\`, \`classList\`, \`matchMedia\`, \`querySelector\`, \`JSON.parse\`) is baseline-supported in Chrome 49+, Firefox 52+, Safari 10.1+, and Edge 16+ — all from 2017 or earlier. IE 11 was discontinued by Microsoft in June 2022, removing the only remaining browser that would have needed polyfilling. The cdnjs polyfill mirror is also residual exposure from the polyfill.io 2024 supply-chain compromise; removing the dependency removes the supply-chain risk.

The \`UA-1265430-2\` Google Analytics tag is dead. Google sunset Universal Analytics on July 1, 2023; new hits are rejected and no data has been collected for nearly two years. The tag still loaded the gtag.js bundle from \`googletagmanager.com\` on every page load (privacy and third-party-request cost) without doing anything useful on the backend.

## Notes

- The site is now running with zero analytics. Picking a replacement (GA4, Plausible, Fathom, Umami, GoatCounter, etc.) is a product/privacy decision rather than a security concern; filed separately as #78.
- The polyfill bundle loaded synchronously and was render-blocking. Removing it eliminates one render-blocking request and one third-party TLS handshake per visit.
- Removing the gtag tag means no more requests to \`googletagmanager.com\` per page load — relevant to the same privacy posture the Google Fonts removal addressed in PR #75.

## Testing

Verified locally with cache wiped (\`rm -rf _site .jekyll-cache\`) and \`bundle exec jekyll serve --livereload --future\`:

- DevTools Network tab shows zero requests to \`cdnjs.cloudflare.com\`, \`googletagmanager.com\`, or \`google-analytics.com\`.
- No JS console errors on home, author, or aggregate post pages — confirms no consumer was relying on a polyfill that was previously injecting a missing global.
- Search, theme toggle, burger menu, home page card list, sidebar "Recent Posts", and per-author sidebar all behave as before.
- View source on rendered pages confirms \`<script src=\"...polyfill...\">\` and \`<script>...gtag...</script>\` are no longer emitted.