### PR TITLE
chore: migrate templates from .tile shim to Bulma 1.x .columns

### DIFF
--- a/_includes/authors.html
+++ b/_includes/authors.html
@@ -1,4 +1,4 @@
-          <div class="tile is-child widget">
+          <div class="widget">
             <div class="card">
               <header class="card-header">
                 <p class="card-header-title nice-title">

--- a/_layouts/aggregate_default.html
+++ b/_layouts/aggregate_default.html
@@ -14,10 +14,8 @@
     </section>
 
     <div class="main-container" style="margin-top:15px;">
-      <div class="tile is-ancestor is-vertical">
 
-
-        <nav class="navbar has-shadow" role="navigation" aria-label="main navigation">
+      <nav class="navbar has-shadow" role="navigation" aria-label="main navigation">
 
           <div class="navbar-brand">
 
@@ -69,49 +67,48 @@
 
         </nav>
 
-        <div class="tile is-parent">
-          <div class="tile is-8 is-child main">
+      <div class="columns">
+        <div class="column is-8 main">
 
-            {{ content }}
+          {{ content }}
 
-          </div>
+        </div>
 
-          <div class="tile is-4 is-child">
-            <div class="tile is-parent is-vertical sidebar">
+        <div class="column is-4">
+          <div class="sidebar">
 
-              <div id="recentAuthorPostsContainer" class="tile is-child widget">
-                <div class="card">
-                  <header class="card-header">
-                    <p class="card-header-title nice-title">
-                    Recent Author Posts
-                    </p>
-                  </header>
-                  <div class="card-content">
-                    <div class="content nice-text">
-                      <ul id="recentAuthorPosts"></ul>
-                    </div>
+            <div id="recentAuthorPostsContainer" class="widget">
+              <div class="card">
+                <header class="card-header">
+                  <p class="card-header-title nice-title">
+                  Recent Author Posts
+                  </p>
+                </header>
+                <div class="card-content">
+                  <div class="content nice-text">
+                    <ul id="recentAuthorPosts"></ul>
                   </div>
                 </div>
               </div>
-
-              <div class="tile is-child widget">
-                <div class="card">
-                  <header class="card-header">
-                    <p class="card-header-title nice-title">
-                    Recent Site Posts
-                    </p>
-                  </header>
-                  <div class="card-content">
-                    <div class="content nice-text">
-                      <ul id="recentPosts"></ul>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              {% include authors.html %}
-
             </div>
+
+            <div class="widget">
+              <div class="card">
+                <header class="card-header">
+                  <p class="card-header-title nice-title">
+                  Recent Site Posts
+                  </p>
+                </header>
+                <div class="card-content">
+                  <div class="content nice-text">
+                    <ul id="recentPosts"></ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {% include authors.html %}
+
           </div>
         </div>
       </div>

--- a/_layouts/author_default.html
+++ b/_layouts/author_default.html
@@ -14,10 +14,8 @@
     </section>
 
     <div class="main-container" style="margin-top:15px;">
-      <div class="tile is-ancestor is-vertical">
 
-
-        <nav class="navbar has-shadow" role="navigation" aria-label="main navigation">
+      <nav class="navbar has-shadow" role="navigation" aria-label="main navigation">
 
           <div class="navbar-brand">
 
@@ -79,49 +77,48 @@
 
         </nav>
 
-        <div class="tile is-parent">
-          <div class="tile is-8 is-child main">
+      <div class="columns">
+        <div class="column is-8 main">
 
-            {{ content }}
+          {{ content }}
 
-          </div>
+        </div>
 
-          <div class="tile is-4 is-child">
-            <div class="tile is-parent is-vertical sidebar">
+        <div class="column is-4">
+          <div class="sidebar">
 
-              <div id="recentAuthorPostsContainer" class="tile is-child widget">
-                <div class="card">
-                  <header class="card-header">
-                    <p class="card-header-title nice-title">
-                    Recent Author Posts
-                    </p>
-                  </header>
-                  <div class="card-content">
-                    <div class="content nice-text">
-                      <ul id="recentAuthorPosts"></ul>
-                    </div>
+            <div id="recentAuthorPostsContainer" class="widget">
+              <div class="card">
+                <header class="card-header">
+                  <p class="card-header-title nice-title">
+                  Recent Author Posts
+                  </p>
+                </header>
+                <div class="card-content">
+                  <div class="content nice-text">
+                    <ul id="recentAuthorPosts"></ul>
                   </div>
                 </div>
               </div>
-
-              <div class="tile is-child widget">
-                <div class="card">
-                  <header class="card-header">
-                    <p class="card-header-title nice-title">
-                    Recent Site Posts
-                    </p>
-                  </header>
-                  <div class="card-content">
-                    <div class="content nice-text">
-                      <ul id="recentPosts"></ul>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              {% include authors.html %}
-
             </div>
+
+            <div class="widget">
+              <div class="card">
+                <header class="card-header">
+                  <p class="card-header-title nice-title">
+                  Recent Site Posts
+                  </p>
+                </header>
+                <div class="card-content">
+                  <div class="content nice-text">
+                    <ul id="recentPosts"></ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {% include authors.html %}
+
           </div>
         </div>
       </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,39 +14,36 @@
     </section>
 
     <div class="main-container" style="margin-top:15px;">
-      <div class="tile is-ancestor is-vertical">
 
-        {% include nav.html %}
+      {% include nav.html %}
 
-        <div class="tile is-parent">
-          <div class="tile is-8 is-child main">
+      <div class="columns">
+        <div class="column is-8 main">
 
-            {{ content }}
+          {{ content }}
 
-          </div>
+        </div>
 
-          <div class="tile is-4 is-child">
-            <div class="tile is-parent is-vertical sidebar">
+        <div class="column is-4">
+          <div class="sidebar">
 
-              <div class="tile is-child widget">
-
-                <div class="card">
-                  <header class="card-header">
-                    <p class="card-header-title nice-title">
-                    Recent Posts
-                    </p>
-                  </header>
-                  <div class="card-content">
-                    <div class="content nice-text">
-                      <ul id="recentPosts"></ul>
-                    </div>
+            <div class="widget">
+              <div class="card">
+                <header class="card-header">
+                  <p class="card-header-title nice-title">
+                  Recent Posts
+                  </p>
+                </header>
+                <div class="card-content">
+                  <div class="content nice-text">
+                    <ul id="recentPosts"></ul>
                   </div>
                 </div>
               </div>
-
-              {% include authors.html %}
-
             </div>
+
+            {% include authors.html %}
+
           </div>
         </div>
       </div>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -220,52 +220,6 @@ blockquote {
   border-left: 5px solid var(--bulma-border-weak);
 }
 
-/*
- * Tile system shim — Bulma 1.x removed the .tile layout primitives.
- * This restores enough of the Bulma 0.9 tile behavior to keep the existing
- * layouts working. Remove when templates migrate to Bulma 1.x .columns.
- */
-.tile {
-  align-items: stretch;
-  display: block;
-  flex-basis: 0;
-  flex-grow: 1;
-  flex-shrink: 1;
-  min-height: min-content;
-}
-.tile.is-ancestor {
-  margin: -0.75rem;
-}
-.tile.is-vertical {
-  flex-direction: column;
-}
-.tile.is-vertical > .tile.is-child:not(:last-child) {
-  margin-bottom: 1.5rem !important;
-}
-@media screen and (min-width: 769px) {
-  .tile:not(.is-child) {
-    display: flex;
-  }
-  .tile.is-1 { flex: none; width: 8.3333333333%; }
-  .tile.is-2 { flex: none; width: 16.6666666667%; }
-  .tile.is-3 { flex: none; width: 25%; }
-  .tile.is-4 { flex: none; width: 33.3333333333%; }
-  .tile.is-5 { flex: none; width: 41.6666666667%; }
-  .tile.is-6 { flex: none; width: 50%; }
-  .tile.is-7 { flex: none; width: 58.3333333333%; }
-  .tile.is-8 { flex: none; width: 66.6666666667%; }
-  .tile.is-9 { flex: none; width: 75%; }
-  .tile.is-10 { flex: none; width: 83.3333333333%; }
-  .tile.is-11 { flex: none; width: 91.6666666667%; }
-  .tile.is-12 { flex: none; width: 100%; }
-}
-.tile.is-parent {
-  padding: 0.75rem;
-}
-.tile.is-child {
-  margin: 0 !important;
-}
-
 div.note {
   border: 1px solid var(--bulma-border);
   background: #fffef4;  /* a really pale yellow */


### PR DESCRIPTION
Closes #66

## What

Replace the deprecated \`.tile\` markup in \`_layouts/default.html\`, \`_layouts/aggregate_default.html\`, \`_layouts/author_default.html\`, and \`_includes/authors.html\` with Bulma 1.x \`.columns\` / \`.column\`. The outer \`tile is-ancestor is-vertical\` wrapper becomes a plain block container; the \`tile is-parent\` row becomes \`<div class="columns">\`; the 8/4 children become \`<div class="column is-8 main">\` and \`<div class="column is-4">\`; the \`tile is-parent is-vertical sidebar\` becomes a plain \`<div class="sidebar">\`; and the \`tile is-child widget\` widget wrappers become plain \`<div class="widget">\`. Delete the 46-line tile-system shim block from \`assets/css/custom.css\`.

## Why

PR #65 vendored Bulma 1.0.4, which removed the \`.tile\` layout primitives entirely. To preserve the existing layouts without rewriting templates in that PR, a temporary CSS shim was added to \`custom.css\`. This PR completes the migration so templates use Bulma's actual grid, and the shim block is no longer needed in the repo.

## Notes

- The \`.tile.is-ancestor.is-vertical\` outer wrapper had a single purpose: vertically stacking the nav above the content row. \`<div>\` elements stack by default in normal flow, so the wrapper has been removed entirely rather than translated to \`.columns.is-vertical\` — that exists but adds complexity for no reason.
- \`.sidebar\` and \`.widget\` are kept as plain div selectors so existing CSS hooks (e.g. \`.sidebar { padding: 0 0.75rem 0.75rem 0.75rem !important; }\` in custom.css) continue to apply unchanged.
- Bulma's \`.columns\` collapses to a single column at mobile widths (< 769px) and goes side-by-side at tablet+, matching the tile system's responsive behavior exactly. No additional \`is-mobile\` / \`is-desktop\` modifiers needed.
- \`_layouts/aggregate_default.html\` and \`_layouts/author_default.html\` still inline their own nav copy rather than using \`_includes/nav.html\`. This pre-existing duplication is unchanged.

## Testing

Verified locally with cache wiped (\`rm -rf _site .jekyll-cache\`) and \`bundle exec jekyll serve --livereload --future\`:

- Home page renders with sidebar (Recent Posts, Authors) on the right at desktop widths, stacked below at mobile widths.
- Any author page (\`/_chrismissal/\`, \`/_jimmybogard/\`, etc.) renders with sidebar (Recent Author Posts, Recent Site Posts, Authors) on the right at desktop widths, stacked below at mobile widths.
- Any aggregate post page renders with the same sidebar pattern.
- Navbar (with theme toggle) still renders correctly across all three layouts.
- Theme toggle still cycles light → dark → system with the right visual result on the new column layout.
- Burger menu still toggles correctly at mobile widths.
- \`grep -rn '\\btile\\b' _layouts _includes assets/css\` returns zero matches.