### PR TITLE
feat: add Google Analytics 4 (GA4) measurement tag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,7 @@ twitter_username: lostechies
 github_username:  lostechies
 #permalink: /:collection/:year/:month/:day/:title/
 rss2json_api_key: "8rtxarjik93svbgojealqe4pzyta8qjzhcdhy40d"
+google_analytics_id: "G-6DK8Y2SBT2"
 
 # Only supported by > Jekyll 3.7.0
 #collections_dir: posts

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -20,3 +20,14 @@
 <script src="{{ site.baseurl }}/assets/js/feed.js"></script>
 <script src="{{ site.baseurl }}/assets/js/load-authors.js"></script>
 <script src="{{ site.baseurl }}/assets/js/load-recent-posts.js"></script>
+
+{% if jekyll.environment == "production" and site.google_analytics_id %}
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics_id }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{ site.google_analytics_id }}');
+</script>
+{% endif %}


### PR DESCRIPTION
Closes #78

## What

Add a GA4 measurement tag wired through \`_config.yml\`. The measurement ID \`G-6DK8Y2SBT2\` is stored in \`_config.yml\` as \`google_analytics_id\`. \`_includes/footer.html\` emits the standard gtag.js snippet only when both conditions hold: \`jekyll.environment == "production"\` and \`site.google_analytics_id\` is set.

## Why

PR #79 removed the dead \`UA-1265430-2\` tag because Universal Analytics was sunset by Google on July 1, 2023 and was collecting no data. This PR re-introduces analytics on the modern GA4 platform under a new property. Putting the measurement ID in \`_config.yml\` keeps future ID changes out of template HTML. The \`jekyll.environment == "production"\` guard prevents local \`jekyll serve\` runs from polluting GA4 — GitHub Pages sets \`JEKYLL_ENV=production\` automatically during deploy builds, so production traffic is captured without needing manual configuration on the server side.

## Notes

- GA4 sets cookies and processes visitor IPs. For EU visitors this technically requires a cookie consent banner for GDPR compliance. Adding consent is out of scope here; can be filed as a follow-up if the audience or legal posture changes.
- The snippet is gated on both the environment AND the config key being set, so removing \`google_analytics_id\` from \`_config.yml\` cleanly disables analytics without touching template code.
- The Liquid key \`google_analytics_id\` uses an underscore to match Jekyll's convention for templated variable names (\`site.google_analytics_id\`).

## Testing

- Run \`bundle exec jekyll serve\` locally (no \`JEKYLL_ENV\`) and view source on any page: no \`googletagmanager.com\` \`<script>\` tag is emitted. Confirms the production guard works.
- Run \`JEKYLL_ENV=production bundle exec jekyll build\` locally and inspect \`_site/index.html\`: the gtag snippet appears with the correct \`G-6DK8Y2SBT2\` ID interpolated.
- After deploy to production: open https://lostechies.com in a browser, then check Google Analytics → Reports → Realtime — your own visit should appear within ~30 seconds.
- Verify DevTools Network tab shows the request to \`https://www.googletagmanager.com/gtag/js?id=G-6DK8Y2SBT2\` only on production, not locally.