### PR TITLE
feat: add GDPR consent banner gating GA4

### DIFF
--- a/_includes/consent_banner.html
+++ b/_includes/consent_banner.html
@@ -1,0 +1,17 @@
+<div id="consent-banner"
+     class="consent-banner"
+     role="dialog"
+     aria-labelledby="consent-banner-title"
+     aria-describedby="consent-banner-text"
+     hidden>
+  <div class="consent-banner-content">
+    <p id="consent-banner-title" class="consent-banner-title">Cookies &amp; analytics</p>
+    <p id="consent-banner-text" class="consent-banner-text">
+      This site uses Google Analytics to understand which posts get read. No analytics cookies are set unless you accept. Nothing here is required for the site to work.
+    </p>
+    <div class="consent-banner-buttons">
+      <button type="button" class="button is-small consent-decline">Decline non-essential</button>
+      <button type="button" class="button is-small is-dark consent-accept">Accept all</button>
+    </div>
+  </div>
+</div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,9 +6,18 @@
         <i class="fa fa-envelope" title="Email"></i>
       </a>
       </p>
+      {% if site.google_analytics_id %}
+      <p class="consent-footer-link">
+        <a href="#cookie-preferences" id="cookie-preferences-link">Cookie preferences</a>
+      </p>
+      {% endif %}
     </div>
   </div>
 </footer>
+
+{% if site.google_analytics_id %}
+{% include consent_banner.html %}
+{% endif %}
 
 <!-- common js -->
 <script src="{{ site.baseurl }}/assets/js/fetch.js"></script>
@@ -21,13 +30,12 @@
 <script src="{{ site.baseurl }}/assets/js/load-authors.js"></script>
 <script src="{{ site.baseurl }}/assets/js/load-recent-posts.js"></script>
 
-{% if jekyll.environment == "production" and site.google_analytics_id %}
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics_id }}"></script>
+{% if site.google_analytics_id %}
 <script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', '{{ site.google_analytics_id }}');
+  window.GA_MEASUREMENT_ID = {{ site.google_analytics_id | jsonify }};
+  {% if jekyll.environment != "production" %}
+  window.ANALYTICS_DRY_RUN = true;
+  {% endif %}
 </script>
+<script src="{{ site.baseurl }}/assets/js/consent.js"></script>
 {% endif %}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -268,3 +268,48 @@ p {
 [data-theme="dark"] .highlight pre {
   background-color: transparent;
 }
+
+/*
+ * GDPR cookie/analytics consent banner. Hidden by default via the [hidden]
+ * attribute; consent.js shows it when no choice is recorded and an
+ * analytics ID is configured.
+ */
+.consent-banner {
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  right: 1rem;
+  max-width: 32rem;
+  margin: 0 auto;
+  padding: 1rem 1.25rem;
+  border-radius: 6px;
+  background: var(--bulma-scheme-main-bis);
+  color: var(--bulma-text);
+  border: 1px solid var(--bulma-border);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  z-index: 1000;
+  font-family: "Open Sans", sans-serif;
+  font-size: 0.875rem;
+}
+
+.consent-banner-title {
+  font-weight: 700;
+  margin: 0 0 0.5rem 0;
+}
+
+.consent-banner-text {
+  margin: 0 0 0.75rem 0;
+  line-height: 1.4;
+}
+
+.consent-banner-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.consent-footer-link {
+  font-size: 0.75rem;
+  margin-top: 0.5rem !important;
+}

--- a/assets/js/consent.js
+++ b/assets/js/consent.js
@@ -1,0 +1,114 @@
+---
+layout: null
+---
+(function () {
+    var STORAGE_KEY = 'analytics-consent';
+    var ACCEPTED = 'accepted';
+    var DECLINED = 'declined';
+
+    function getStored() {
+        try {
+            return localStorage.getItem(STORAGE_KEY);
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function setStored(value) {
+        try {
+            localStorage.setItem(STORAGE_KEY, value);
+        } catch (e) {}
+    }
+
+    function loadAnalytics() {
+        if (!window.GA_MEASUREMENT_ID) return;
+        if (document.getElementById('gtag-script')) return;
+
+        if (window.ANALYTICS_DRY_RUN) {
+            console.log('[consent] dry run: would load GA4 with id ' + window.GA_MEASUREMENT_ID);
+            return;
+        }
+
+        var script = document.createElement('script');
+        script.async = true;
+        script.id = 'gtag-script';
+        script.src = 'https://www.googletagmanager.com/gtag/js?id=' + encodeURIComponent(window.GA_MEASUREMENT_ID);
+        document.head.appendChild(script);
+
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { window.dataLayer.push(arguments); }
+        window.gtag = gtag;
+        gtag('js', new Date());
+        gtag('config', window.GA_MEASUREMENT_ID);
+    }
+
+    var previousFocus = null;
+
+    function onKeydown(e) {
+        if (e.key === 'Escape' || e.keyCode === 27) {
+            e.preventDefault();
+            hideBanner();
+        }
+    }
+
+    function showBanner() {
+        var banner = document.getElementById('consent-banner');
+        if (!banner) return;
+        previousFocus = document.activeElement;
+        banner.hidden = false;
+        var declineBtn = banner.querySelector('.consent-decline');
+        if (declineBtn && declineBtn.focus) declineBtn.focus();
+        document.addEventListener('keydown', onKeydown);
+    }
+
+    function hideBanner() {
+        var banner = document.getElementById('consent-banner');
+        if (banner) banner.hidden = true;
+        document.removeEventListener('keydown', onKeydown);
+        if (previousFocus && previousFocus.focus) {
+            try { previousFocus.focus(); } catch (e) {}
+        }
+        previousFocus = null;
+    }
+
+    function accept() {
+        setStored(ACCEPTED);
+        hideBanner();
+        loadAnalytics();
+    }
+
+    function decline() {
+        setStored(DECLINED);
+        hideBanner();
+    }
+
+    function init() {
+        if (!window.GA_MEASUREMENT_ID) return;
+
+        var current = getStored();
+        if (current === ACCEPTED) {
+            loadAnalytics();
+        } else if (current !== DECLINED) {
+            showBanner();
+        }
+
+        var acceptBtn = document.querySelector('#consent-banner .consent-accept');
+        var declineBtn = document.querySelector('#consent-banner .consent-decline');
+        if (acceptBtn) acceptBtn.addEventListener('click', accept);
+        if (declineBtn) declineBtn.addEventListener('click', decline);
+
+        var prefLink = document.getElementById('cookie-preferences-link');
+        if (prefLink) {
+            prefLink.addEventListener('click', function (e) {
+                e.preventDefault();
+                showBanner();
+            });
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();


### PR DESCRIPTION
## What

Add a hand-rolled GDPR cookie/analytics consent banner that gates GA4 loading on explicit user action. New \`_includes/consent_banner.html\` ships the dialog markup (hidden by default via the \`hidden\` attribute). New \`assets/js/consent.js\` owns show/hide logic, keyboard accessibility, localStorage persistence, and dynamic injection of \`gtag.js\` only after the user clicks Accept. \`assets/css/custom.css\` gets the banner styling appended (themed via Bulma CSS variables so it adapts to dark mode automatically). \`_includes/footer.html\` is rewritten to emit \`window.GA_MEASUREMENT_ID\` via Liquid's \`jsonify\` filter, include the banner markup, load \`consent.js\`, and add a "Cookie preferences" footer link that re-opens the banner after a choice has been made.

## Why

PR #81 added the GA4 measurement tag but loaded \`gtag.js\` unconditionally on every production page view — not GDPR-compliant for EU visitors. This PR gates the GA4 script injection on an explicit "Accept all" click; "Decline non-essential" records the choice and never loads any third-party tracking. Escape dismisses without recording, so the banner re-appears on the next visit (consent must be explicit, not implicit). The implementation is hand-rolled to match the codebase's existing posture (theme.js follows the same pattern); if more third-party scripts are added later, switching to a library with category-based consent (\`cookieconsent\` v3, Klaro) would scale better.

## Notes

- The banner is non-modal (no \`aria-modal\`): page scrolling is not blocked. \`role="dialog"\` is declared, Escape closes, focus moves to the Decline button on show and restores on close. Focus trap is intentionally not implemented since the banner is non-modal.
- GA4 ID is interpolated via \`{{ site.google_analytics_id | jsonify }}\` rather than bare string concat, so future \`_config.yml\` values containing quotes or \`</script>\` cannot escape the JS string context.
- A \`window.ANALYTICS_DRY_RUN\` flag is set in non-production builds. In that mode, \`consent.js\` logs \`[consent] dry run: ...\` to console instead of injecting \`gtag.js\` — local testing of the banner UI does not pollute production analytics.
- A three-model security review (opus/sonnet/haiku) flagged three additional findings that were **considered and intentionally not addressed in this PR**:
  - **localStorage tampering**: any same-origin script can set \`localStorage['analytics-consent'] = 'accepted'\` and bypass the banner on the next load. Accepted risk — no first-party untrusted scripts run on the site, and HMAC-signing the consent value is overkill for a personal blog.
  - **Inline scripts block strict CSP**: \`_includes/footer.html\` and \`_includes/head.html\` both have inline \`<script>\` blocks. A future \`script-src 'self'\` CSP would require nonces or moving the data to meta tags. Deferred — CSP is not currently on the roadmap.
  - **\`JEKYLL_ENV=production\` not asserted at build time**: if a future deploy mechanism forgets to set the env var, \`ANALYTICS_DRY_RUN\` would silently ship to production and analytics would never fire. GitHub Pages currently sets this automatically; deferred.

## Testing

Verified locally with cache wiped (\`rm -rf _site .jekyll-cache\`) and \`bundle exec jekyll serve --livereload --future\`:

- First visit: banner appears at bottom of page with Decline / Accept buttons.
- Click **Accept**: banner hides, DevTools console logs \`[consent] dry run: would load GA4 with id "G-6DK8Y2SBT2"\`, no network request to \`googletagmanager.com\` (because \`ANALYTICS_DRY_RUN\` is true locally), \`localStorage['analytics-consent'] === 'accepted'\`.
- Click **Decline**: banner hides, no console log, \`localStorage['analytics-consent'] === 'declined'\`, no GA4 load.
- Press **Escape** while banner is showing: banner hides, no localStorage entry written.
- Reload after Escape: banner re-appears (consent must be explicit, no decision recorded).
- Reload after Accept or Decline: banner stays hidden.
- Click **Cookie preferences** in footer: banner re-opens, can change choice.
- **Keyboard a11y**: Tab moves focus into Decline button when banner is open; Escape closes; focus returns to the previously-focused element after close.
- **DevTools Network tab in production** (after merge + deploy): clicking Accept should produce the request to \`https://www.googletagmanager.com/gtag/js?id=G-6DK8Y2SBT2\`. Visits should appear in Google Analytics → Reports → Realtime within ~30s.