### PR TITLE
feat: simplify theme toggle to light/dark with current-view icon

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,13 +10,10 @@
     (function () {
       try {
         var stored = localStorage.getItem('theme');
-        var theme = (stored === 'light' || stored === 'dark' || stored === 'system') ? stored : 'system';
-        if (theme === 'system') {
-          if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-            document.documentElement.setAttribute('data-theme', 'dark');
-          }
-        } else {
-          document.documentElement.setAttribute('data-theme', theme);
+        if (stored === 'light' || stored === 'dark') {
+          document.documentElement.setAttribute('data-theme', stored);
+        } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+          document.documentElement.setAttribute('data-theme', 'dark');
         }
       } catch (e) {}
     })();

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -41,7 +41,7 @@
           <a href="{{ site.feed.path }}" class="navbar-item"><img src="{{ site.baseurl }}/assets/images/rss.png"/></a>
           <a class="navbar-item theme-toggle" role="button" aria-label="Toggle theme" title="Toggle theme">
             <span class="icon">
-              <i class="fa fa-desktop" aria-hidden="true"></i>
+              <i class="fa fa-moon-o" aria-hidden="true"></i>
             </span>
           </a>
         </div>

--- a/_layouts/aggregate_default.html
+++ b/_layouts/aggregate_default.html
@@ -58,7 +58,7 @@
               <a href="{{ site.feed.path }}" class="navbar-item"><img src="{{ site.baseurl }}/assets/images/rss.png"/></a>
               <a class="navbar-item theme-toggle" role="button" aria-label="Toggle theme" title="Toggle theme">
                 <span class="icon">
-                  <i class="fa fa-desktop" aria-hidden="true"></i>
+                  <i class="fa fa-moon-o" aria-hidden="true"></i>
                 </span>
               </a>
             </div>

--- a/_layouts/author_default.html
+++ b/_layouts/author_default.html
@@ -68,7 +68,7 @@
               <a href="{{ site.feed.path }}" class="navbar-item"><img src="{{ site.baseurl }}/assets/images/rss.png"/></a>
               <a class="navbar-item theme-toggle" role="button" aria-label="Toggle theme" title="Toggle theme">
                 <span class="icon">
-                  <i class="fa fa-desktop" aria-hidden="true"></i>
+                  <i class="fa fa-moon-o" aria-hidden="true"></i>
                 </span>
               </a>
             </div>

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -3,50 +3,48 @@ layout: null
 ---
 (function () {
     var STORAGE_KEY = "theme";
-    var THEMES = ["light", "dark", "system"];
     var ICONS = {
         light: "fa-sun-o",
-        dark: "fa-moon-o",
-        system: "fa-desktop"
+        dark: "fa-moon-o"
     };
 
     function getStoredTheme() {
         try {
             var stored = localStorage.getItem(STORAGE_KEY);
-            return THEMES.indexOf(stored) >= 0 ? stored : "system";
+            return (stored === "light" || stored === "dark") ? stored : null;
         } catch (e) {
-            return "system";
+            return null;
         }
+    }
+
+    function getCurrentTheme() {
+        var stored = getStoredTheme();
+        if (stored) {
+            return stored;
+        }
+        var prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+        return prefersDark ? "dark" : "light";
     }
 
     function applyTheme(theme) {
-        if (theme === "system") {
-            var prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
-            if (prefersDark) {
-                document.documentElement.setAttribute("data-theme", "dark");
-            } else {
-                document.documentElement.removeAttribute("data-theme");
-            }
-        } else {
-            document.documentElement.setAttribute("data-theme", theme);
-        }
+        document.documentElement.setAttribute("data-theme", theme);
     }
 
     function updateButtons(theme) {
+        var nextLabel = theme === "dark" ? "Switch to light theme" : "Switch to dark theme";
         var buttons = document.querySelectorAll(".theme-toggle");
         for (var i = 0; i < buttons.length; i++) {
             var icon = buttons[i].querySelector(".fa");
             if (icon) {
                 icon.className = "fa " + ICONS[theme];
             }
-            buttons[i].setAttribute("aria-label", "Theme: " + theme + " (click to change)");
-            buttons[i].setAttribute("title", "Theme: " + theme + " (click to change)");
+            buttons[i].setAttribute("aria-label", nextLabel);
+            buttons[i].setAttribute("title", nextLabel);
         }
     }
 
-    function cycleTheme() {
-        var current = getStoredTheme();
-        var next = THEMES[(THEMES.indexOf(current) + 1) % THEMES.length];
+    function toggleTheme() {
+        var next = getCurrentTheme() === "dark" ? "light" : "dark";
         try {
             localStorage.setItem(STORAGE_KEY, next);
         } catch (e) {}
@@ -55,22 +53,23 @@ layout: null
     }
 
     function init() {
-        var current = getStoredTheme();
-        updateButtons(current);
+        updateButtons(getCurrentTheme());
 
         var buttons = document.querySelectorAll(".theme-toggle");
         for (var i = 0; i < buttons.length; i++) {
             buttons[i].addEventListener("click", function (e) {
                 e.preventDefault();
-                cycleTheme();
+                toggleTheme();
             });
         }
 
         if (window.matchMedia) {
             var mql = window.matchMedia("(prefers-color-scheme: dark)");
             var onChange = function () {
-                if (getStoredTheme() === "system") {
-                    applyTheme("system");
+                if (getStoredTheme() === null) {
+                    var sys = mql.matches ? "dark" : "light";
+                    applyTheme(sys);
+                    updateButtons(sys);
                 }
             };
             if (mql.addEventListener) {


### PR DESCRIPTION
## What

Remove the three-state `light` → `dark` → `system` cycle from the theme toggle. The button now flips between `light` and `dark` only, and the icon reflects the currently displayed view (moon when dark, sun when light) rather than the stored preference. Touched files: `_includes/head.html` (boot script no longer special-cases the string `"system"`), `assets/js/theme.js` (cycle dropped, `updateButtons` driven by current view, accessible labels describe the next action), and `_includes/nav.html` / `_layouts/aggregate_default.html` / `_layouts/author_default.html` (static `fa-desktop` fallback replaced with `fa-moon-o`).

## Why

The `system` state was a third click in a cycle that most users would never need, and the desktop icon did not convey anything meaningful about the current page appearance. Showing the icon of the current view (and labelling the button with the action it performs) is more discoverable. The OS preference is still honored on first visit and whenever no explicit choice has been stored, so the "follow system" behavior is preserved without occupying a slot in the cycle.

## Notes

- Users with a legacy `localStorage.theme === "system"` value are treated as having no preference. Their next click cleanly overwrites the slot with `"light"` or `"dark"` — no migration script needed, no data wipe.
- The static `fa-moon-o` in nav/layout markup is a JS-disabled fallback only. Once `theme.js` runs (synchronously after DOM ready), the icon is corrected to match the actual displayed theme on every page.
- `aria-label` / `title` now describe the action ("Switch to light theme") rather than the state, since the icon already communicates state. Screen reader users get the verb; sighted users get the glyph.
- `_layouts/aggregate_default.html` and `_layouts/author_default.html` still inline their own nav rather than using `_includes/nav.html`. Pre-existing duplication carried forward; unchanged by this PR.

## Testing

Verified locally with `bundle exec jekyll serve --livereload`:

- **Icon matches current view on load**: with OS in dark mode and no stored preference, page renders dark and the toggle shows the moon. Switch OS to light, refresh, page renders light and the toggle shows the sun.
- **Toggle flips and icon swaps**: clicking the button flips `data-theme` on `<html>` and swaps the icon in the same render.
- **Persistence**: after a click, `localStorage.getItem('theme')` returns `"light"` or `"dark"`; refresh keeps the chosen theme.
- **System default with no preference**: `localStorage.removeItem('theme')` + refresh follows OS `prefers-color-scheme` and shows the matching icon.
- **Live OS change with no preference**: with no stored preference, flipping OS dark/light updates the page and icon without a refresh (via the `matchMedia` change listener).
- **Legacy `"system"` value**: `localStorage.setItem('theme','system')` + refresh behaves as if no preference is stored; next click cleanly overwrites with `"light"` or `"dark"`.
- **Built output is clean**: `bundle exec jekyll build` succeeds; grep of `_site/` for `fa-desktop`, `cycleTheme`, and the literal string `"system"` in `_site/assets/js/theme.js` and `_site/index.html` returns nothing.

## Screenshots

### Dark

<img width="207" height="94" alt="Screenshot 2026-06-05 at 16 35 15" src="https://github.com/user-attachments/assets/96a14f1f-17ae-454f-a8af-d97c1fb83368" />

### Light

<img width="190" height="82" alt="Screenshot 2026-06-05 at 16 35 20" src="https://github.com/user-attachments/assets/1d59c59c-5a86-45e5-842f-883c8b7fb230" />

